### PR TITLE
Switches _ to ` for pandoc latex of inline code

### DIFF
--- a/hunts/ntfs_extended_attribute_analysis.md
+++ b/hunts/ntfs_extended_attribute_analysis.md
@@ -4,7 +4,7 @@
 
 **Data Required**: NTFS Master File Table (MFT) data from a single host
 
-**Collection Considerations**: Run _fget.exe_ on each NTFS filesystem on a host to capture the raw data, then parse into records and fields with something like _analyzeMFT.py_
+**Collection Considerations**: Run `fget.exe` on each NTFS filesystem on a host to capture the raw data, then parse into records and fields with something like `analyzeMFT.py`
 
 **Analysis Techniques**: Stack counting
 
@@ -15,7 +15,7 @@ The MFT holds detailed metadata about files and directories on a file system.  T
 Stack the data by full path and filename, "EA" an "EA Information" fields.  Look for:
 
 * Rare values in the MFT "EA" or "EA Information" fields.  There may be some legitimate use of these in your environment, but hopefully these uses will have a high count.
-    * Anything in _/Windows/winsxs_ or _/Windows/CSC_ is probably legit
+    * Anything in `/Windows/winsxs` or `/Windows/CSC` is probably legit
 
 
 **Other Notes**

--- a/hunts/psexec-windows-events.md
+++ b/hunts/psexec-windows-events.md
@@ -16,8 +16,8 @@ Filtering
 
 Look for Windows Event ID 5145, _A network share object was checked to
 see whether client can be granted desired access_.  Filter for events
-where the share is _IPC$_ and the service is _PSEXECSVC-*_.  Cross
-reference by examining the 5145 events for access to the _ADMIN$_
+where the share is `IPC$` and the service is `PSEXECSVC-*`.  Cross
+reference by examining the 5145 events for access to the `ADMIN$`
 share for tool/file copies and execution events.
 
 **Other Notes** Psexec is one of the most common mechanisms for

--- a/hunts/suspicious_process_creation_via_windows_event_logs.md
+++ b/hunts/suspicious_process_creation_via_windows_event_logs.md
@@ -23,18 +23,18 @@ stack counting
 
 Search all process creation log entries and look for:
 
-* _svchost.exe_ processes that are not children of _services.exe_
+* `svchost.exe` processes that are not children of `services.exe`
 * Processes created by binaries in unsual locations, such as
-	* _%windows%\fonts_
-	* _%windows%\help_
-	* _%windows%\wbem_
-	* _%windows%\addins_
-	* _%windows%\debut_
-	* _%windows%\system32\tasks_
+	* `%windows%\fonts`
+	* `%windows%\help`
+	* `%windows%\wbem`
+	* `%windows%\addins`
+	* `%windows%\debut`
+	* `%windows%\system32\tasks`
 * Known attacker tool names, such as
-	* _rar.exe_
-  	* _psexec.exe_
-  	* _whoami.exe_
+	* `rar.exe`
+  	* `psexec.exe`
+  	* `whoami.exe`
 
 * Processes that launched very few times during a 24 hour period
 

--- a/hunts/webshells.md
+++ b/hunts/webshells.md
@@ -13,7 +13,7 @@ Web server logs (apache, IIS, etc.)
 Collect from all webservers, and ensure that parameters are collected.  
 POST data should be collected.  
 
-* For apache consider using mod_security or mod_dumpio
+* For apache consider using `mod_security` or `mod_dumpio`
 * For IIS use [Failed Request Tracing / Custom Logging](http://serverfault.com/a/90965)
 
 **Analysis Techniques**: 
@@ -29,7 +29,7 @@ String matching
         * Stack by unique visits per IP -- most only visit the webshell (no other page hits, no js, no images, etc.)
             * this isn't true of injected webshells (where they are injected into an existing page)
         * Stack by UA uniqueness.  This is not always rock solid, but good, because many webshells have client software that sets the UA and many don't change the default
-* Look for parameters passed to image files (e.g., /bad.png?zz=ls)
+* Look for parameters passed to image files (e.g., `/bad.png?zz=ls`)
 * More specific to inject webshells that inject into an existing page:
     * Stack by parameter counts per page -- webshells that create new params on an existing page 
         * Again, you can look if referer is missing, UA uniqueness
@@ -37,8 +37,8 @@ String matching
 **Other Notes**  
 Endpoint detection strategies:
 * Look for creation of processes whose parent is the webserver (e.g., apache, w3wp.exe); these will come from functions like:
-    * PHP functions like exec(), shell_exec(), etc.
-    * asp(.net) functions like eval(), bind(), etc.)
+    * PHP functions like `exec()`, `shell_exec()`, etc.
+    * asp(.net) functions like `eval()`, `bind()`, etc.)
 * Looking for file additions or file changes (if you have a change management process and schedule to easily differentiate 'known good') -- (using something like inotify on linux (or FileSystemWatcher in .NET), to monitor the webroot folder(s) recursively)
 
 

--- a/hunts/windows_autoruns_analysis.md
+++ b/hunts/windows_autoruns_analysis.md
@@ -4,7 +4,7 @@
 
 **Data Required**: List of programs configured to start at boot/logon time on each endpoint
 
-**Collection Considerations**: MS Sysinternals' _autorunsc.exe_ is the most common way to collect this from a host
+**Collection Considerations**: MS Sysinternals' `autorunsc.exe` is the most common way to collect this from a host
 
 **Analysis Techniques**: Stack counting, string matching, outlier detection
 
@@ -12,7 +12,7 @@
 
 Gather autoruns data from endpoints across the network and look for:
 
-* Executable starting out of _c:programdata_, recycle bin, appdata area, %temp%
+* Executable starting out of `c:programdata`, recycle bin, appdata area, `%temp%`
 * Unsigned executables
 * Shortest / longest filenames 
 * GUID filenames

--- a/hunts/windows_driver_analysis.md
+++ b/hunts/windows_driver_analysis.md
@@ -4,7 +4,7 @@
 
 **Data Required**: List of drivers loaded on each endpoint
 
-**Collection Considerations**: Typically use the _driverquery_ command on each host.
+**Collection Considerations**: Typically use the `driverquery` command on each host.
 
 **Analysis Techniques**: Stack counting
 

--- a/hunts/windows_prefetch_cache_analysis.md
+++ b/hunts/windows_prefetch_cache_analysis.md
@@ -4,7 +4,7 @@
 
 **Data Required**: Windows prefetch cache data
 
-**Collection Considerations**: Requires a special tool to convert binary file format to something we can consume (e.g., Nirsoft _WinPrefetchView_. Probably needs an agent.
+**Collection Considerations**: Requires a special tool to convert binary file format to something we can consume (e.g., Nirsoft `WinPrefetchView`. Probably needs an agent.
 
 **Analysis Techniques**: Stack counting, outlier detection
 

--- a/hunts/windows_service_analysis.md
+++ b/hunts/windows_service_analysis.md
@@ -2,19 +2,19 @@
 
 **Purpose**: Find suspicious Windows services running across a network
 
-**Data Required**: Info about running services on endpoints; For _svchost_ services, list of DLLs loaded inside
+**Data Required**: Info about running services on endpoints; For `svchost` services, list of DLLs loaded inside
 
-**Collection Considerations**: May need a host agent (e.g., MS Sysinternals _psservice.exe_ and _listdlls.exe_) to collect this regularly.  Some Windows systems log service configuration, start & stop events, which might also be useful.
+**Collection Considerations**: May need a host agent (e.g., MS Sysinternals `psservice.exe` and `listdlls.exe`) to collect this regularly.  Some Windows systems log service configuration, start & stop events, which might also be useful.
 
 **Analysis Techniques**: Stack counting
 
 **Description**
 
-An example of the data returned by _psservice.exe_ is:
+An example of the data returned by `psservice.exe` is:
 
-SERVICE_NAME: ALG  
-DISPLAY_NAME: Applica+on Layer Gateway Service  
-Provides support for 3rd party protocol plug-ins for Internet Connec+on Sharing
+  SERVICE_NAME: ALG  
+  DISPLAY_NAME: Applicaton Layer Gateway Service  
+  Provides support for 3rd party protocol plug-ins for Internet Connec+on Sharing
 
      TYPE : 10 WIN32_OWN_PROCESS
      START_TYPE : 3 DEMAND_START
@@ -42,13 +42,13 @@ An example of _listdlls_ output is:
 
 Look for 
 
-* Rare SERVICE_NAME or DISPLAY_NAME values
+* Rare `SERVICE_NAME` or `DISPLAY_NAME` values
     * GUID service names
     * Random service names
 * Blank fields which normally hold values
-* Unusual directories in the BINARY_PATH_NAME 
+* Unusual directories in the `BINARY_PATH_NAME`
 
-For _svchost_ services, list all DLLs loaded inside them (using _listdlls_) and look for:
+For `svchost` services, list all DLLs loaded inside them (using `listdlls`) and look for:
 
 * Rare DLLs and/or locations
 * Unsigned DLLs or those with invalid signatures


### PR DESCRIPTION
Some file paths and other code with special characters were labeled
emphasis. Switching these to inline code allows clean conversions
with pandoc.
